### PR TITLE
Update rkhunter.conf.erb

### DIFF
--- a/templates/etc/rkhunter.conf.erb
+++ b/templates/etc/rkhunter.conf.erb
@@ -897,7 +897,7 @@ OS_VERSION_FILE="<%= @os_version_file %>"
 RTKT_DIR_WHITELIST="<%= rtktdirwhitelist %>
 <% end -%>
 <% rtkt_file_whitelist.each do |rtktfilewhitelist| -%>
-RTKT_DIR_WHITELIST="<%= rtktfilewhitelist %>"
+RTKT_FILE_WHITELIST="<%= rtktfilewhitelist %>"
 <% end -%>
 
 #


### PR DESCRIPTION
rkhunter fails otherwise since /var/log/pki-ca/system isn't a directory when FreeIPA is installed
