### PR TITLE
Adding a couple of common entries to the default whitelists

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -219,6 +219,7 @@ class rkhunter::params {
       '/dev/.udev/queue.bin',
       '/dev/.udev/db/*',
       '/dev/.udev/rules.d/99-root.rules',
+      '/dev/.udev/uevent_seqnum',
       '/dev/md/autorebuild.pid', # created by mdadm
       '/dev/shm/sem.slapd-*.stats', # 389 Directory Server
     ],

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -136,6 +136,11 @@ class rkhunter::params {
       '/etc/.git',
       '/etc/.bzr',
     ],
+    'Debian' => [
+      '/etc/.java',
+      '/dev/.udev',
+      '/dev/.initramfs',
+    ],
     default  => [
 #      '/etc/.java',
 #      '/dev/.static',


### PR DESCRIPTION
The default whitelists are missing a standard file for CentOS/Redhat 5, and don't include anything for Debian. I added a couple of extra entries.