### PR TITLE
Fix deprecated mode set and add auto --propupd

### DIFF
--- a/manifests/packages.pp
+++ b/manifests/packages.pp
@@ -12,6 +12,7 @@ class rkhunter::packages {
   
   # Run rkhunter --propupd after installation of package
   exec { '/usr/bin/rkhunter --propupd':
+    unless => '/usr/bin/test -f /var/lib/rkhunter/db/rkhunter_prop_list.dat',
     subscribe => Package['rkhunter'],
   }
 }

--- a/manifests/packages.pp
+++ b/manifests/packages.pp
@@ -6,7 +6,12 @@ class rkhunter::packages {
 
   file { '/usr/local/bin/rktask':
     ensure => file,
-    mode   => 755,
+    mode   => '0755',
     source => 'puppet:///modules/rkhunter/rktask'
+  }
+  
+  # Run rkhunter --propupd after installation of package
+  exec { '/usr/bin/rkhunter --propupd':
+    subscribe => Package['rkhunter'],
   }
 }


### PR DESCRIPTION
Non-string values for the file mode property are deprecated. It must be a string, either a symbolic mode like 'o+w,a+r' or an octal representation like '0644' or '755'.
Added /usr/bin/rkhunter --propupd to autorun after installation of package.