### PR TITLE
Add dependencies, a required field.

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -18,5 +18,7 @@
     {
       "operatingsystem": "FreeBSD"
     }
-   ]
+   ],
+  "dependencies": [
+  ]
 }


### PR DESCRIPTION
Fixes silently ignoring a broken metadata.json in 3.6.2 claiming
Error: Could not find class rkhunter